### PR TITLE
fixes broken workspace preview

### DIFF
--- a/Classes/Controller/FrontendController.php
+++ b/Classes/Controller/FrontendController.php
@@ -394,7 +394,7 @@ class FrontendController extends AbstractPlugin
                             && isset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/classes/class.frontendedit.php']['edit']);
 
                         if ($GLOBALS['TSFE']->fePreview && $GLOBALS['TSFE']->beUserLogin && !$GLOBALS['TSFE']->workspacePreview && !$this->conf['disableExplosivePreview'] && !$feedit) {
-                            $content = $this->visualID($content, $row['tx_templavoilaplus_ds'], $dsObj, $TOrec, $row, $table);
+                            $content = $this->visualID($content, $row['tx_templavoilaplus_ds'], $DS, $TOrec, $row, $table);
                         }
                     } else {
                         $content = $this->formatError('Template Object could not be unserialized successfully.


### PR DESCRIPTION
from Slack:

> bug in the WsPreview
> 
> [16:46]  
> in typo3conf/ext/templavoilaplus/Classes/Controller/FrontendController.php:398 you pass an object "$dsObj" as parameter. the visualID function expects an array
> 
> [16:47]  
> the array is seemingly the DS record, which is not handled accordingly in the DataStorage object u pass
> 
> [16:49]  
> i guess what you want to pass is the $DS-array

passes $DS array to $this->visualID function