### PR TITLE
[FEATURE] allow multiple folders for static datastructures

### DIFF
--- a/Classes/Controller/BackendTemplateMappingController.php
+++ b/Classes/Controller/BackendTemplateMappingController.php
@@ -23,6 +23,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 use Ppi\TemplaVoilaPlus\Utility\TemplaVoilaUtility;
 use Ppi\TemplaVoilaPlus\Utility\DataStructureUtility;
+use Ppi\TemplaVoilaPlus\Controller\Update\StaticDataUpdateController;
 
 $GLOBALS['LANG']->includeLLFile(
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('templavoilaplus') . 'Resources/Private/Language/BackendTemplateMapping.xlf'
@@ -885,6 +886,7 @@ class BackendTemplateMappingController extends \TYPO3\CMS\Backend\Module\BaseScr
                     if ($this->staticDS) {
                         $title = preg_replace('|[/,\."\']+|', '_', $this->_saveDSandTO_title) . ' (' . ($this->_saveDSandTO_type == 1 ? 'page' : 'fce') . ').xml';
                         $path = GeneralUtility::getFileAbsFileName($this->_saveDSandTO_type == 2 ? $this->extConf['staticDS.']['path_fce'] : $this->extConf['staticDS.']['path_page']) . $title;
+                        $path = DataStructureUtility::getFirstDirectoryInList($path);
                         GeneralUtility::writeFile($path, $dataProtXML);
                         $newID = substr($path, strlen(PATH_site));
                     } else {

--- a/Classes/Controller/Update/StaticDataUpdateController.php
+++ b/Classes/Controller/Update/StaticDataUpdateController.php
@@ -64,7 +64,7 @@ class StaticDataUpdateController
                         $ok[0] = false;
                         $description .= sprintf('||' . TemplaVoilaUtility::getLanguageService()->sL('LLL:EXT:templavoilaplus/Resources/Private/Language/template_conf.xlf:staticDS.wizard.dircheck.notset'), 'staticDS.path_fce');
                     } else {
-                        $ok[0] = $this->checkDirectory($conf['staticDS.']['path_fce']);
+                        $ok[0] = $this->checkDirectory(DataStructureUtility::getFirstDirectoryInList($conf['staticDS.']['path_fce']));
                         if ($ok[0]) {
                             $description .= sprintf('||' . TemplaVoilaUtility::getLanguageService()->sL('LLL:EXT:templavoilaplus/Resources/Private/Language/template_conf.xlf:staticDS.wizard.dircheck.ok'), htmlspecialchars($conf['staticDS.']['path_fce']));
                         } else {
@@ -76,7 +76,7 @@ class StaticDataUpdateController
                         $ok[0] = false;
                         $description .= sprintf('||' . TemplaVoilaUtility::getLanguageService()->sL('LLL:EXT:templavoilaplus/Resources/Private/Language/template_conf.xlf:staticDS.wizard.dircheck.notset'), 'staticDS.path_page');
                     } else {
-                        $ok[1] = $this->checkDirectory($conf['staticDS.']['path_page']);
+                        $ok[1] = $this->checkDirectory(DataStructureUtility::getFirstDirectoryInList($conf['staticDS.']['path_page']));
                         if ($ok[1]) {
                             $description .= sprintf('|' . TemplaVoilaUtility::getLanguageService()->sL('LLL:EXT:templavoilaplus/Resources/Private/Language/template_conf.xlf:staticDS.wizard.dircheck.ok'), htmlspecialchars($conf['staticDS.']['path_page']));
                         } else {
@@ -178,6 +178,7 @@ class StaticDataUpdateController
             </tr></thead><tbody>';
         foreach ($rows as $row) {
             $dirPath = GeneralUtility::getFileAbsFileName($row['scope'] == 2 ? $conf['path_fce'] : $conf['path_page']);
+            $dirPath = DataStructureUtility::getFirstDirectoryInList($dirPath);
             $dirPath = $dirPath . (substr($dirPath, -1) == '/' ? '' : '/');
             $title = $this->makeCleanFileName($row['title']);
             $pathAndFilename = $dirPath . $title . '.xml';

--- a/Classes/Utility/DataStructureUtility.php
+++ b/Classes/Utility/DataStructureUtility.php
@@ -23,6 +23,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 final class DataStructureUtility
 {
+    const pathDelimiter = ';';
+    
     static function array2xml(array $dataStructure)
     {
         $indentation = 0;
@@ -45,5 +47,13 @@ final class DataStructureUtility
             $indentation,
             ['useCDATA' => 1]
         );
+    }
+    
+    static function getFirstPathInList($pathList) {
+        return(static::getPathArray($pathList)[0]);
+    }
+    
+    static function getPathArrayFromList($pathList) {
+        return(explode(static::pathDelimiter,$pathList));
     }
 }

--- a/Resources/Private/Language/PluginConfiguration.xlf
+++ b/Resources/Private/Language/PluginConfiguration.xlf
@@ -19,10 +19,10 @@
                 <source>Enable static files for data structures:Experimental! Use Static DS Conversion Wizard below!</source>
             </trans-unit>
             <trans-unit id="staticDS.path_fce" xml:space="preserve">
-                <source>FCE Data Structure Path:Path to the static data structures for flexible content elements</source>
+                <source>FCE Data Structure Path:Path to the static data structures for flexible content elements. Use ';' as a delimiter for multiple paths, first path should be writeable (e.g. starting with fileadmin/).</source>
             </trans-unit>
             <trans-unit id="staticDS.path_page" xml:space="preserve">
-                <source>Page Data Structure Path:Path to the static data structures for pages</source>
+                <source>Page Data Structure Path:Path to the static data structures for pages. Use ';' as a delimiter for multiple paths, first path should be writeable (e.g. starting with fileadmin/).</source>
             </trans-unit>
             <trans-unit id="staticDS.updater" xml:space="preserve">
                 <source>Updater</source>


### PR DESCRIPTION
Idea:
A templavoila datastructure is tightly coupled with it's template. Although one could argue, that most templates might be "main content" and "sidebar" content, this doesn't need to be the case and if merging two systems, although the structure might be the same, the naming of the fields might not be. Additionally a datasctructure might also support really complex options and fields. Thus a datastructure and template combination might be called unique. Of course for "one design" an
administrator will probably make a combined datastructure for all templates.
Nevertheless a TYPO3 instance can hold multiple designs (e.g. per domain). As it is best practice nowadays to define a web template as an extension this means that the static datastructures should be supplied in the very same extension.
This leads to the necessity to define more than one folder in extension configuration, e.g. multiple paths separated by a semicolon (colon perhaps breaks volume-path-separator on Windows), as using a fileadmin/templates folder doesn't make sense then.

Solution:
As the path is used for selecting a DS and creating new DS, one path needs to be writeable. The easiest way for this, would be to have the first path "as is" and use additional paths just for DS selection. Added this in the description of the config option

- For all access to staticDS.path_page and .path_fce a "getFirstDirectoryInList" is used.
- For the pull-down menu for TOBJ all paths are used.

Resolves: #65