### PR TITLE
SectionIndexController->mainAction : allow use of field:xxx

### DIFF
--- a/Classes/Controller/SectionIndexController.php
+++ b/Classes/Controller/SectionIndexController.php
@@ -47,6 +47,9 @@ class SectionIndexController
         $contentIds = array();
         if ($pids) {
             $pageIds = GeneralUtility::trimExplode(',', $pids);
+            if (substr($pageId, 0, 6) === "field:") {
+                $pageId = $this->cObj->data[substr($pageId, 6)];
+            }
             foreach ($pageIds as $pageId) {
                 $page = $GLOBALS['TSFE']->sys_page->checkRecord('pages', $pageId);
                 if (isset($page) && isset($page['tx_templavoilaplus_flex'])) {


### PR DESCRIPTION
I have the following situation :
in a page, I loop over the children pages, and fetch the content of a TV field. I use the following TS template in the page's setup :
```typoscript
lib.mypage = CONTENT
lib.mypage.table = pages
lib.mypage.select {
  orderBy = sorting ASC
}
lib.mypage.renderObj = COA
lib.mypage.renderObj {
  10 = TEXT
  10 {
    field = title
  }
  20 = USER
  20 {
    select.pidInList = field:uid
    userFunc = Ppi\TemplaVoilaPlus\Controller\SectionIndexController->mainAction
    indexField = field_entete
  }
}
```

The proposed PR allows the use of "field:xxx" for the "select.pidInList" parameter.
