### PR TITLE
[BUGFIX] skips rendering of flexform markup for FCE fields with eType "none" (Element Preset: Typoscript only)

### DIFF
--- a/Classes/Form/Container/FlexFormElementContainer.php
+++ b/Classes/Form/Container/FlexFormElementContainer.php
@@ -67,6 +67,7 @@ class FlexFormElementContainer extends AbstractContainer
                 !is_array($flexFormFieldArray)
                 // Not a section or container and not a list of single items
                 || (!isset($flexFormFieldArray['type']) && !is_array($flexFormFieldArray['config']))
+				|| ($flexFormFieldArray['tx_templavoilaplus']['eType'] == 'none')
             ) {
                 continue;
             }


### PR DESCRIPTION
prevents BE flexforms of FCEs from containing empty section lines