### PR TITLE
[BUGFIX] Fix DS preview icon generating error and display

### DIFF
--- a/Classes/Controller/BackendControlCenterController.php
+++ b/Classes/Controller/BackendControlCenterController.php
@@ -627,7 +627,7 @@ class BackendControlCenterController extends \TYPO3\CMS\Backend\Module\BaseScrip
 
         // Preview icon:
         if ($dsObj->getIcon()) {
-            $previewIcon = '<img src="' . $this->getThumbnail($dsObj->getIcon()) . '" alt="" />';
+            $previewIcon = '<img src="' . $this->getThumbnail(realpath($dsObj->getIcon())) . '" alt="" />';
         } else {
             $previewIcon = TemplaVoilaUtility::getLanguageService()->getLL('noicon', true);
         }
@@ -683,6 +683,12 @@ class BackendControlCenterController extends \TYPO3\CMS\Backend\Module\BaseScrip
                     <td>' . TemplaVoilaUtility::getLanguageService()->getLL('updated', true) . '</td>
                     <td>' . BackendUtility::datetime($dsObj->getTstamp()) . '</td>
                 </tr>
+                ' . ($previewIcon ?
+		        '<tr>
+                    <td></td>
+                    <td>' . TemplaVoilaUtility::getLanguageService()->getLL('preview', true) . '</td>
+                    <td>' . $previewIcon . '</td>
+                </tr>' : '') . '
             </tbody>
         </table>';
 


### PR DESCRIPTION
This fixes a bug with static DS icon files causing error in backend module.
I found that in TYPO 7.6.23 if I have file /fileadmin/templates/ds/fce/myFCE.xml and /fileadmin/templates/ds/fce/myFCE.gif then I got the error:
```
Uncaught TYPO3 Exception
#1320286857: File ../fileadmin/templates/ds/fce/myFCE.gif is not valid (".." and "//" is not allowed in path).
```
This happens in Resource object / factory which expects valid htdocs - relative path.

More - it seems that $previewIcon that causes the problem defined in line 630 is not even used anywhere in code (was removed in one of revisions and forgotten).

I fixed the thumbnail generating line and added conditional displaying it in the info table.