### PR TITLE
[BUGFIX] Fixed data structure wizard name in tmplobj TCA configuration

### DIFF
--- a/Configuration/TCA/tx_templavoilaplus_tmplobj.php
+++ b/Configuration/TCA/tx_templavoilaplus_tmplobj.php
@@ -105,7 +105,7 @@ return [
                             'setValue' => 'set'
                         ],
                         'module' => [
-                            'name' => 'wizard_add.php'
+                            'name' => 'wizard_add'
                         ]
                     ]
                 ]


### PR DESCRIPTION
Fixed error `#1289918325: Module wizard_add.php is not configured.` when trying to create Data Structure via wizard.