### PR TITLE
[FEATURE] add tt_content.layout as CSS class to BEmodule output

### DIFF
--- a/Classes/Controller/BackendLayoutController.php
+++ b/Classes/Controller/BackendLayoutController.php
@@ -1354,7 +1354,7 @@ class BackendLayoutController extends \TYPO3\CMS\Backend\Module\BaseScriptClass
 
                 $elementTitlebarClass = 't3-page-ce-header '
                     . ($elementBelongsToCurrentPage ? 'tpm-titlebar' : 'tpm-titlebar-fromOtherPage');
-                $elementClass .= ' t3-page-ce tpm-content-element tpm-ctype-' . $contentTreeArr['el']['CType'];
+                $elementClass .= ' t3-page-ce tpm-content-element tpm-ctype-' . $contentTreeArr['el']['CType'] . ' tpm-layout-' . $contentTreeArr['el']['layout'];
 
                 if ($contentTreeArr['el']['isHidden']) {
                     $elementClass .= ' tpm-hidden t3-page-ce-hidden';

--- a/Classes/Service/ApiService.php
+++ b/Classes/Service/ApiService.php
@@ -1511,6 +1511,7 @@ class ApiService
             'sys_language_uid' => $row['sys_language_uid'],
             'l18n_parent' => $row['l18n_parent'],
             'CType' => $row['CType'],
+            'layout' => $row['layout'],
             'TO' => $row['tx_templavoilaplus_to'],
         );
 


### PR DESCRIPTION
The Backend module outputs many HTML/CSS classes for content
elements according to the fields in the tt_content table (e.g.
CType, tx_templavoilaplus_tobj). Obviously the field 'layout'
should by definition have an optional impact on the output as well.

One could argue that this must not be the case and that each
arbitrary tt_content field might be relevant, however layout was
designed for this purpose in the first place. So I propose to add
this specific field to the output.

This would improve the option to style the backend module with a
custom CSS via the PageTSconfig
mod.web_txtemplavoilaplusLayout.stylesheet.myvalue  = path/to/my.css