### PR TITLE
[BUGFIX] deprecation notice in backend Page module on php 7.2

### DIFF
--- a/Classes/Controller/BackendLayoutController.php
+++ b/Classes/Controller/BackendLayoutController.php
@@ -1714,10 +1714,9 @@ class BackendLayoutController extends \TYPO3\CMS\Backend\Module\BaseScriptClass
             //replace lang markers
             $beTemplate = preg_replace_callback(
                 "/###(LLL:[\w-\/:]+?\.xml\:[\w-\.]+?)###/",
-                create_function(
-                    '$matches',
-                    'return $GLOBALS["LANG"]->sL($matches[1], 1);'
-                ),
+                function($matches) {
+                    return $GLOBALS["LANG"]->sL($matches[1], 1);
+                },
                 $beTemplate
             );
 


### PR DESCRIPTION
create_function() is deprecated in php 7.2 and it displays notice in Page module. Changed to anonymous function.