### PR TITLE
Move pages.tx_templavoila_flex to own tab, instead of cluttering tab 'general'

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -108,9 +108,8 @@ if (!$oldPageModule) {
     );
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
         'pages',
-        'tx_templavoilaplus_flex',
-        '',
-        'after:title'
+        '--div--;LLL:EXT:templavoilaplus/Resources/Private/Language/locallang_db.xlf:pages.tab.tx_templavoilaplus_flex,tx_templavoilaplus_flex',
+        ''
     );
 } else {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette(
@@ -119,12 +118,11 @@ if (!$oldPageModule) {
         '--linebreak--, tx_templavoilaplus_to, tx_templavoilaplus_next_to',
         'after:backend_layout_next_level'
     );
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
-        'pages',
-        'tx_templavoilaplus_flex',
-        '',
-        'after:title'
-    );
+        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+            'pages',
+            '--div--;LLL:EXT:templavoilaplus/Resources/Private/Language/locallang_db.xlf:pages.tab.tx_templavoilaplus_flex,tx_templavoilaplus_flex',
+            ''
+        );
 }
 
 $GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['contains-tv+'] = 'extensions-templavoila-folder';

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -96,6 +96,9 @@
 			<trans-unit id="pages.tx_templavoilaplus_flex" xml:space="preserve">
 				<source>Content:</source>
 			</trans-unit>
+			<trans-unit id="pages.tab.tx_templavoilaplus_flex" xml:space="preserve">
+				<source>TemplaVoilà! Plus Content</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
In a recent design I got a page datastructure which has a whole lot of tt_content fields. Thus, while editing a page datarow, the pages.general tab gets cluttered. Normally I won't mind that, but the current position of the fields is quite early. That made using the page types "shortcut" and "external url" difficult, because their url target fields were below the pages.tx_templavoila_flex, thus not even on my screen. Editors find that annoying. Although that should be solved by the core team moving the url target fields next to the page type, I consider an easier approach:

**Assumptions:**
- adding pages.tx_templavoila_flex at a new position "last element of general tab" is quite impossible hard due to all the page types (and page types being different in different LTS versions)
- the field should probably be never changed in "edit pages datarow" anyways, but instead in TV+ page module, so it could be deemed as not that important and thus shouldn't be that prominent

**Suggestion:** 
Thus, I suggest to move them to an own tab, at the end of the list of tabs.
<img width="856" alt="WIWI-chairT3_dev_System_vom_2019-04-07__TYPO3_CMS_8_7_24_" src="https://user-images.githubusercontent.com/12411176/55689785-25bc4d80-5989-11e9-8b7e-d8f3f2b1d921.png">