### PR TITLE
 @schneiel Fixed header parsing bug if head tag is not set since TYPO3 8.7.32 ELTS and TYPO3 9.5.29 LTS.

### DIFF
--- a/Classes/Controller/BackendTemplateMappingController.php
+++ b/Classes/Controller/BackendTemplateMappingController.php
@@ -879,7 +879,10 @@ class BackendTemplateMappingController extends \TYPO3\CMS\Backend\Module\BaseScr
                 // Get <head>...</head> from template:
                 $splitByHeader = $this->markupObj->htmlParse->splitIntoBlock('head', $fileContent);
                 // There should be only one head tag
-                $html_header = $this->markupObj->htmlParse->removeFirstAndLastTag($splitByHeader[1]);
+                $html_header = '';
+                if (is_string($splitByHeader)) {
+                    $html_header = $this->markupObj->htmlParse->removeFirstAndLastTag($splitByHeader[1]);
+                }
 
                 $this->markupObj->tags = $this->head_markUpTags; // Set up the markupObject to process only header-section tags:
 
@@ -1788,7 +1791,10 @@ class BackendTemplateMappingController extends \TYPO3\CMS\Backend\Module\BaseScr
             // Get <head>...</head> from template:
             $splitByHeader = $this->markupObj->htmlParse->splitIntoBlock('head', $fileContent);
             // There should be only one head tag
-            $html_header = $this->markupObj->htmlParse->removeFirstAndLastTag($splitByHeader[1]);
+            $html_header = '';
+            if (is_string($splitByHeader)) {
+                $html_header = $this->markupObj->htmlParse->removeFirstAndLastTag($splitByHeader[1]);
+            }
 
             $this->markupObj->tags = $this->head_markUpTags; // Set up the markupObject to process only header-section tags:
 
@@ -1912,7 +1918,11 @@ class BackendTemplateMappingController extends \TYPO3\CMS\Backend\Module\BaseScr
         // Get <head>...</head> from template:
         $splitByHeader = $this->markupObj->htmlParse->splitIntoBlock('head', $fileContent);
         // There should be only one head tag
-        $html_header = $this->markupObj->htmlParse->removeFirstAndLastTag($splitByHeader[1]);
+
+        $html_header = '';
+        if (is_string($splitByHeader)) {
+            $html_header = $this->markupObj->htmlParse->removeFirstAndLastTag($splitByHeader[1]);
+        }
 
         // Set up the markupObject to process only header-section tags:
         $this->markupObj->tags = $this->head_markUpTags;


### PR DESCRIPTION
See https://github.com/TYPO3/typo3/blob/bf181a7500ada580b77f5587f25c9ed72c1a1113/typo3/sysext/core/Classes/Html/HtmlParser.php#L192

If **$splitByHeader[1]** is empty, because there isn't a header tag, an exception is thrown:
`Argument 1 passed to TYPO3\CMS\Core\Html\SimpleParser::fromString() must be of the type string, null given, called in /var/www/ekbo/vendor/typo3/cms/typo3/sysext/core/Classes/Html/HtmlParser.php on line 194`

The class **HtmlParser** was refactored in TYPO 8.7.32 ELTS and TYPO3 9.5.29 LTS. At the same time the class was designed type safe, that is why the error occurs in that case.