### PR TITLE
[BUGFIX] if create record wizard fails this is catched silently instead of handled

### DIFF
--- a/Classes/Service/ApiService.php
+++ b/Classes/Service/ApiService.php
@@ -181,8 +181,10 @@ class ApiService
 
         $tce->start($dataArr, array());
         $tce->process_datamap();
-        if ($this->debug && count($tce->errorLog)) {
-            GeneralUtility::devLog('API: insertElement_createRecord(): tcemain failed', 'templavoilaplus', 0, array('errorLog' => $tce->errorLog));
+        if (count($tce->errorLog)) {
+            if ($this->debug) {
+                GeneralUtility::devLog('API: insertElement_createRecord(): tcemain failed', 'templavoilaplus', 0, array('errorLog' => $tce->errorLog));
+            }
             throw new \InvalidArgumentException(implode('; ', $tce->errorLog), 1636745166);
         }
         $newUid = $tce->substNEWwithIDs['NEW'];

--- a/Classes/Service/ApiService.php
+++ b/Classes/Service/ApiService.php
@@ -183,6 +183,7 @@ class ApiService
         $tce->process_datamap();
         if ($this->debug && count($tce->errorLog)) {
             GeneralUtility::devLog('API: insertElement_createRecord(): tcemain failed', 'templavoilaplus', 0, array('errorLog' => $tce->errorLog));
+            throw new \InvalidArgumentException(implode('; ', $tce->errorLog), 1636745166);
         }
         $newUid = $tce->substNEWwithIDs['NEW'];
         if (!$flagWasSet) {


### PR DESCRIPTION
Creating a record via wizard should create record and then edit it, however if the creation of the record fails because tt_content was extended sloppy (wrong default values, required fields which are not set), this creation fails and the edit will throw the wrong exception `$uid must be positive integer, 0 given` because not uid was returned.

This patch throws the exception early and thus allows to find the error more easy