### PR TITLE
Replace DeletedRestriction with where() in update script

### DIFF
--- a/Classes/Controller/Backend/ControlCenter/TemplaVoilaPlus8UpdateController.php
+++ b/Classes/Controller/Backend/ControlCenter/TemplaVoilaPlus8UpdateController.php
@@ -271,12 +271,14 @@ class TemplaVoilaPlus8UpdateController extends AbstractUpdateController
             ->getQueryBuilderForTable('tx_templavoilaplus_datastructure');
         $queryBuilder
             ->getRestrictions()
-            ->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+            ->removeAll();
 
         $result = $queryBuilder
             ->select('*')
             ->from('tx_templavoilaplus_datastructure')
+            ->where(
+                $queryBuilder->expr()->neq('deleted', $queryBuilder->createNamedParameter(1, \PDO::PARAM_BOOL))
+            )
             ->orderBy('pid')
             ->execute()
             ->fetchAll();
@@ -306,12 +308,14 @@ class TemplaVoilaPlus8UpdateController extends AbstractUpdateController
             ->getQueryBuilderForTable('tx_templavoilaplus_tmplobj');
         $queryBuilder
             ->getRestrictions()
-            ->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+            ->removeAll();
 
         $result = $queryBuilder
             ->select('*')
             ->from('tx_templavoilaplus_tmplobj')
+            ->where(
+                $queryBuilder->expr()->neq('deleted', $queryBuilder->createNamedParameter(1, \PDO::PARAM_BOOL))
+            )
             ->orderBy('pid')
             ->execute()
             ->fetchAll();


### PR DESCRIPTION
There are two queries on tx_templavoilaplus_tmplobj and tx_templavoilaplus_datastructure that use the DeletedRestriction class to exclude soft deleted records but the TCA configuration file for those two tables has been removed in 8.0.0.