### PR TITLE
Fix TYPO3\CMS\Core\Configuration\Loader\Exception\YamlFileLoadingException when loading mappings on Windows

### DIFF
--- a/Classes/Handler/LoadSave/YamlLoadSaveHandler.php
+++ b/Classes/Handler/LoadSave/YamlLoadSaveHandler.php
@@ -33,7 +33,7 @@ class YamlLoadSaveHandler extends AbstractFileLoadSaveHandler implements LoadSav
 
         /** @var YamlFileLoader */
         $yamlFileLoader = GeneralUtility::makeInstance(YamlFileLoader::class);
-        $yamlContent = $yamlFileLoader->load($file->getPathname());
+        $yamlContent = $yamlFileLoader->load(GeneralUtility::fixWindowsFilePath($file->getPathname()));
 
         return $yamlContent;
     }


### PR DESCRIPTION
The `\SplFileInfo::getPathname()` function returns a backslash between the folder path and file name on Windows and the TYPO3 YamlFileLoader class calls `GeneralUtility::getFileAbsFileName($filename)` which returns '' if there is a backslash in the path (verified in `GeneralUtility::validPathStr($filename)`).