### PR TITLE
ignore fields with <type>no_map</type>

### DIFF
--- a/Classes/Controller/Backend/ControlCenter/TemplaVoilaPlus8UpdateController.php
+++ b/Classes/Controller/Backend/ControlCenter/TemplaVoilaPlus8UpdateController.php
@@ -1169,6 +1169,12 @@ class TemplaVoilaPlus8UpdateController extends AbstractUpdateController
         $domXpath = new \DOMXPath($domDocument);
 
         foreach ($mappingInformation as $fieldName => $mappingField) {
+            // ignore fields with <type>no_map</type>. field value was used in TypoScript 
+            // in same templavoila datastructure only.
+            if('' === $mappingField['MAP_EL']){
+                continue;
+            }
+
             list($xPath, $mappingType) = explode('/', $mappingField['MAP_EL']);
 
             $convertedXPath = $this->convertXPath($xPath);

--- a/Classes/Handler/Render/XpathRenderHandler.php
+++ b/Classes/Handler/Render/XpathRenderHandler.php
@@ -42,16 +42,15 @@ class XpathRenderHandler implements RenderHandlerInterface
 
         $entries = $this->domXpath->query($mapping['xpath']);
 
-        if ($entries->count() === 1) {
-            $node = $entries->item(0);
+        $html = '';
+        foreach($entries as $entry) {
             if (isset($mapping['container']) && is_array($mapping['container'])) {
-                $this->processContainer($node, $mapping['container'], $processedValues, 'box');
+                $this->processContainer($entry, $mapping['container'], $processedValues, 'box');
             }
-
-            return $this->getHtml($node, $mapping['mappingType']);
+            $html .= $this->getHtml($entry, $mapping['mappingType']);
         }
 
-        return '';
+        return $html;
     }
 
     public function processHeaderInformation(TemplateConfiguration $templateConfiguration)


### PR DESCRIPTION
This little workaround helps me to get further and the TemplaVoilaPlus8Update script is not throwing a exception ```The old mapping path "" could not be converted```. Maybe i have a very rare use case using not mapped field values in TypoScript in same data structure.
Does anybody know if the value of no_map fields are available in same Typoscript as variable/constant?