### PR TITLE
[TASK] PseudoSiteFinder not available in 10LTS

### DIFF
--- a/Classes/Utility/TemplaVoilaUtility.php
+++ b/Classes/Utility/TemplaVoilaUtility.php
@@ -19,6 +19,7 @@ use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Site\Entity\NullSite;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Database\Query\Restriction\BackendWorkspaceRestriction;
@@ -213,8 +214,12 @@ final class TemplaVoilaUtility
             try {
                 $site = $siteFinder->getSiteByPageId((int)$pageId);
             } catch (\TYPO3\CMS\Core\Exception\SiteNotFoundException $e) {
-                $pseudoSiteFinder = GeneralUtility::makeInstance(PseudoSiteFinder::class);
-                $site = $pseudoSiteFinder->getSiteByPageId($pageId);
+                if (class_exists(PseudoSiteFinder::class)) {
+                    $pseudoSiteFinder = GeneralUtility::makeInstance(PseudoSiteFinder::class);
+                    $site = $pseudoSiteFinder->getSiteByPageId($pageId);
+                } else {
+                    $site = GeneralUtility::makeInstance(NullSite::class);
+                }
             }
             if ($backendUserAuth) {
                 $foundLanguages = $site->getAvailableLanguages($backendUserAuth);


### PR DESCRIPTION
TemplaVoilaUtility::getUseableLanguages() tries to get the languages for the BackendModule. If the sites are not positioned on the site root, but deeper, there are tree nodes without sites. TVP used PseudoSiteFinder for those cases, however 10LTS dropped it.

In core the solution is to use a NullSite, e.g. https://api.typo3.org/10.4/class_t_y_p_o3_1_1_c_m_s_1_1_core_1_1_routing_1_1_site_matcher.html#a6821b949a0dc9742279e6c0339ceaa78

Same proposed here.