### PR TITLE
[BUGFIX] page module shows exception if a FCE has no mapping

### DIFF
--- a/Resources/Private/Language/Backend/PageLayout.xlf
+++ b/Resources/Private/Language/Backend/PageLayout.xlf
@@ -111,6 +111,9 @@
             <trans-unit id="newContentElementWizard.fce" xml:space="preserve">
                 <source>FCE</source>
             </trans-unit>
+            <trans-unit id="error.fce.noMapping" xml:space="preserve">
+                <source>Error: This FCE has no mapping set.</source>
+            </trans-unit>
 
 
         </body>

--- a/Resources/Private/Partials/Backend/Preview/Templavoilaplus_pi1.html
+++ b/Resources/Private/Partials/Backend/Preview/Templavoilaplus_pi1.html
@@ -1,27 +1,36 @@
 {namespace tvp=Tvp\TemplaVoilaPlus\ViewHelpers}
 
-<f:variable name="labelFromItemlist" value="{tvp:backend.labelFromItemlist(table:'tt_content', fieldName:'CType', key:'{node.raw.entity.CType}')}" />
-<f:variable name="nameMappingConfiguration" value="{tvp:backend.labelFromMappingConfiguration(identifier:'{node.raw.entity.tx_templavoilaplus_map}')}" />
-<f:if condition="{labelFromItemlist} || {nameMappingConfiguration}">
-    <strong>
+<f:if condition="{node.raw.entity.tx_templavoilaplus_map}">
+  <f:then>
+    <f:variable name="labelFromItemlist" value="{tvp:backend.labelFromItemlist(table:'tt_content', fieldName:'CType', key:'{node.raw.entity.CType}')}"/>
+    <f:variable name="nameMappingConfiguration" value="{tvp:backend.labelFromMappingConfiguration(identifier:'{node.raw.entity.tx_templavoilaplus_map}')}"/>
+    <f:if condition="{labelFromItemlist} || {nameMappingConfiguration}">
+      <strong>
         <f:if condition="{labelFromItemlist}">
-            <f:translate key="{labelFromItemlist}" default="{labelFromItemlist}" />
+          <f:translate key="{labelFromItemlist}" default="{labelFromItemlist}"/>
         </f:if>
         <f:if condition="{nameMappingConfiguration}">
-            <f:translate key="{nameMappingConfiguration}" default="{nameMappingConfiguration}" />
+          <f:translate key="{nameMappingConfiguration}" default="{nameMappingConfiguration}"/>
         </f:if>
-    </strong>
-    <br />
-</f:if>
-
-<f:for each="{node.datastructure.sheets.sDEF.ROOT.el}" key="fieldName" as="fieldConfig">
-    <f:if condition="{fieldConfig.TCEforms.label}">
-        <strong><f:translate key="{fieldConfig.TCEforms.label}" default="{fieldConfig.TCEforms.label}" /></strong>
+      </strong>
+      <br/>
     </f:if>
-    <f:format.crop maxCharacters="2000">
+
+    <f:for each="{node.datastructure.sheets.sDEF.ROOT.el}" key="fieldName" as="fieldConfig">
+      <f:if condition="{fieldConfig.TCEforms.label}">
+        <strong>
+          <f:translate key="{fieldConfig.TCEforms.label}" default="{fieldConfig.TCEforms.label}"/>
+        </strong>
+      </f:if>
+      <f:format.crop maxCharacters="2000">
         <tvp:format.wordLength maxCharacters="75">
-            <tvp:format.stripTags whitespace="true">{node.flexform.data.sDEF.lDEF.{fieldName}.vDEF}</tvp:format.stripTags>
+          <tvp:format.stripTags whitespace="true">{node.flexform.data.sDEF.lDEF.{fieldName}.vDEF}</tvp:format.stripTags>
         </tvp:format.wordLength>
-    </f:format.crop>
-    <br>
-</f:for>
+      </f:format.crop>
+      <br>
+    </f:for>
+  </f:then>
+  <f:else>
+    <f:translate key="LLL:EXT:templavoilaplus/Resources/Private/Language/Backend/PageLayout.xlf:error.fce.noMapping"/>
+  </f:else>
+</f:if>


### PR DESCRIPTION
There might be the case a tt_content FCE has no mapping, e.g. if an existing tt_content is
switched to type FCE, not setting a mapping and saving.

This patch changes the output template to show a warning message for that element to catch
that exception.