### PR TITLE
[FEATURE] allow non-clickable backend record previews

### DIFF
--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node.html
@@ -49,7 +49,7 @@
             </f:if>
             <f:render partial="Backend/Handler/DoktypeDefaultHandler/Node/Childs" arguments="{node: node, beLayout: beLayout}" />
         </f:if>
-        <div class="tvp-record-edit">
+        <div class="tvp-record-preview">
             <f:render partial="Backend/Handler/DoktypeDefaultHandler/PreviewContent" arguments="{node: node}" />
         </div>
 

--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/Localizations.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/Localizations.html
@@ -21,7 +21,7 @@
                                     <div class="tvp-record-edit">
                                         <f:render partial="Backend/Handler/DoktypeDefaultHandler/Node/TypeInformation" arguments="{node: '{node.localization.{language.uid}}'}"/>
                                     </div>
-                                    <div class="tvp-record-edit">
+                                    <div class="tvp-record-preview">
                                         <f:render partial="Backend/Handler/DoktypeDefaultHandler/PreviewContent" arguments="{node: '{node.localization.{language.uid}}'}"/>
                                     </div>
 

--- a/Resources/Public/JavaScript/PageLayout.js
+++ b/Resources/Public/JavaScript/PageLayout.js
@@ -579,6 +579,15 @@ class PageLayout {
                 that.openRecordEdit(origItem.dataset.recordTable, origItem.dataset.recordUid);
             })
         }
+
+        var allPreviews = base.querySelectorAll('div.tvp-node .tvp-record-preview:not(:has(.disable-tvp-preview-onclick))');
+
+        for (const item of allPreviews) {
+            item.addEventListener('click', function (event) {
+                var origItem = item.closest('.tvp-node');
+                that.openRecordEdit(origItem.dataset.recordTable, origItem.dataset.recordUid);
+            });
+        }
     }
 
     initClipboardAddListener = function(base) {


### PR DESCRIPTION
The backend module utilizes core preview render to show meaningful previews, however the rendered content is always linked to the edit form. While this probably makes sense for most content, there are cases where the preview could show special buttons, especially in case of plugins to not only interact with that tt_content record but perhaps with other records (e.g. a powermail form pointing to actual registration records). Thus, it should be possible to suppress linking of the whole preview.

This changes the current wrap to .tvp-record-preview and supports the use of an class .disable-tvp-preview-onclick to wrap own previews optionally.