### PR TITLE
[TASK] remove exception if no flexPointer in rootline

### DIFF
--- a/Classes/Configuration/FlexForm/ParsingModifyEventListener.php
+++ b/Classes/Configuration/FlexForm/ParsingModifyEventListener.php
@@ -115,16 +115,6 @@ class ParsingModifyEventListener
                 } else {
                     $pointerValue = $row[$pointerFieldName];
                 }
-                if (!$pointerValue && ((int)$row[$parentFieldName] === 0 || $row[$parentFieldName] === null)) {
-                    // If on root level and still no valid pointer found -> exception
-                    throw new FlexFormInvalidPointerFieldException(
-                        'The data structure for field "' . $fieldName . '" in table "' . $tableName . '" has to be looked up'
-                        . ' in field "' . $pointerFieldName . '". That field had no valid value, so a lookup in parent record'
-                        . ' with uid "' . $row[$parentFieldName] . '" was done. Root node with uid "' . $row['uid'] . '"'
-                        . ' was fetched and still no valid pointer field value was found.',
-                        1464112555
-                    );
-                }
             }
         }
 


### PR DESCRIPTION
I get `FlexFormInvalidPointerFieldException()` raised during CLI `bin/typo3 referenceindex:update` via [`Classes/Configuration/FlexForm/ParsingModifyEventListener.php:120`](https://github.com/T3Voila/templavoilaplus/blob/aa465326fa776fb255d0ac8198c8598625e1575b/Classes/Configuration/FlexForm/ParsingModifyEventListener.php#L120) because I have a complex page tree above actual sites, e.g.:
```
0 TYPO3 root
^- A 
|  ^-A.a 
|    ^ site1 
|
^- B
```
So the first page to have a TVP mapping or data structure is site1, the sys folders above have empty values. This seems like a valid construct, so I suggest to remove the exception because empty pointers seems ok by definition (although I get its general benefits for debugging).
