### PR TITLE
[BUGFIX] contentElementWizard AJAX breaks on missing icon

### DIFF
--- a/Resources/Private/Templates/Backend/Ajax/ContentElements.html
+++ b/Resources/Private/Templates/Backend/Ajax/ContentElements.html
@@ -17,7 +17,9 @@
                     <div class="tvp-node tvp-node-newce card dragHandle" data-record-table="tt_content" data-panel="newcontent" data-element-row="{contentElement.element-row -> f:format.json()}">
                         <div class="card-header">
                             <div class="container-fluid tvp-node-header">
+                                <f:if condition="{contentElement.iconIdentifier}">
                                 <div class="tvp-node-header-icons-left"><core:icon identifier="{contentElement.iconIdentifier}" size="medium" /></div>
+                                </f:if>
                                 <div class="tvp-node-title">
                                     {contentElement.title}
                                     <div class="tvp-node-description">{contentElement.description}</div>


### PR DESCRIPTION
A simple missing icon configuration results in the whole CEW not showing anything in 13LTS:
```
TYPO3\CMS\Core\Imaging\IconFactory::getIcon(): Argument #1 ($identifier) must be of type string, null given, called in /vendor/typo3/cms-core/Classes/ViewHelpers/IconViewHelper.php on line 65
```

Proposed fix: just add an if before calling core:icon