### PR TITLE
[BUGFIX] deprecation 91473 doesRecordExist - argument 3 is now an int

### DIFF
--- a/Classes/Service/DataHandling/DataHandler.php
+++ b/Classes/Service/DataHandling/DataHandler.php
@@ -505,7 +505,7 @@ class DataHandler
                     }
                 }
             }
-            if (($res == 1) && !$pObj->doesRecordExist($table, $id, 'editcontent')) {
+            if (($res == 1) && !$pObj->doesRecordExist($table, $id, 2)) {
                 $res = null;
             }
         }


### PR DESCRIPTION
Found in the logs, not via editor request. seems to be some internals called during the new
`/typo3/ajax/redirects/revert/correlation`
Method signature deprecated in 11LTS