### PR TITLE
[BUGFIX] missing contextMenu on PageModule Node TitleBarLeftButtons

### DIFF
--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TitleBarLeftButtons.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TitleBarLeftButtons.html
@@ -1,5 +1,9 @@
 <div class="t3-page-ce-header-icons-left tvp-node-header-icons-left">
-    <a href="#" class="t3js-contextmenutrigger" data-table="{node.raw.table}" data-uid="{node.raw.entity.uid}" data-context="1">
+    <a href="#" data-context="1"
+       data-contextmenu-trigger="click"
+       data-contextmenu-table="{node.raw.table}"
+       data-contextmenu-uid="{node.raw.entity.uid}"
+       title="id={node.raw.entity.uid}">
         <span data-bs-toggle="tooltip" data-bs-title="{node.rendering.hintTitle}" data-bs-html="true" data-bs-placement="right" data-bs-original-title="" title="">
             <core:iconForRecord table="{node.raw.table}" row="{node.raw.entity}" />
         </span>

--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Page/Localizations/TitleBarLeftButtons.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Page/Localizations/TitleBarLeftButtons.html
@@ -1,5 +1,9 @@
 <div class="t3-page-ce-header-icons-left tvp-node-header-icons-left">
-    <a href="#" class="t3js-contextmenutrigger" data-table="{node.raw.table}" data-uid="{node.raw.entity.uid}" data-context="1">
+    <a href="#" data-context="1"
+       data-contextmenu-trigger="click"
+       data-contextmenu-table="{node.raw.table}"
+       data-contextmenu-uid="{node.raw.entity.uid}"
+       title="id={node.raw.entity.uid}">
         <span data-bs-toggle="tooltip" data-bs-title="{node.rendering.hintTitle}" data-bs-html="true" data-bs-placement="right" data-bs-original-title="" title="">
             <core:iconForRecord table="{node.raw.table}" row="{node.raw.entity}" />
         </span>


### PR DESCRIPTION
The record buttons in page module didn't spawn a contextMenu anymore.
The code says that this probably was broken longer but that doesn't make sense, probably a deprecation and auto-conversion which was recently removed